### PR TITLE
rtl_tcp: fix -T arg

### DIFF
--- a/src/rtl_tcp.c
+++ b/src/rtl_tcp.c
@@ -393,7 +393,7 @@ int main(int argc, char **argv)
 	struct sigaction sigact, sigign;
 #endif
 
-	while ((opt = getopt(argc, argv, "a:p:f:g:s:b:d:P:T:D")) != -1) {
+	while ((opt = getopt(argc, argv, "a:p:f:g:s:b:d:P:DT")) != -1) {
 		switch (opt) {
 		case 'd':
 			dev_index = verbose_device_search(optarg);


### PR DESCRIPTION
Currently option -T takes argument, but it's not required, I had to write `rtl_tcp -T 1` instead of `rtl_tcp -T` all the time