### PR TITLE
Fix implicit funciton definition in tuner_r82xx.c

### DIFF
--- a/src/tuner_r82xx.c
+++ b/src/tuner_r82xx.c
@@ -26,6 +26,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "rtl-sdr.h"
 #include "rtlsdr_i2c.h"
 #include "tuner_r82xx.h"
 


### PR DESCRIPTION
* Add include statement to fix implicit function definition compile error in Clang, etc.

Note: It feels like the GPIO segment of the librtlsdr module deserves to have its own header file like i2c does to better separate the components.