### PR TITLE
Further clarification of GPIO relationship

### DIFF
--- a/src/rtl_adsb.c
+++ b/src/rtl_adsb.c
@@ -96,7 +96,7 @@ void usage(void)
 		"\t[-e allowed_errors (default: 5)]\n"
 		"\t[-g tuner_gain (default: automatic)]\n"
 		"\t[-p ppm_error (default: 0)]\n"
-		"\t[-T enable bias-T on GPIO PIN 0 (works for rtl-sdr.com v3/v4 dongles)]\n"
+		"\t[-T enable bias-T on dongle's GPIO PIN 0 (works for rtl-sdr.com v3/v4 dongles)]\n"
 		"\tfilename (a '-' dumps samples to stdout)\n"
 		"\t (omitting the filename also uses stdout)\n\n"
 		"Streaming with netcat:\n"


### PR DESCRIPTION
The dongle's GPIO is referred to, not the host computer's (e.g., Raspberry Pi's).