### PR TITLE
CMakeLists.txt: Increase to version 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 
 # workaround for https://gitlab.kitware.com/cmake/cmake/issues/16967
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0")


### PR DESCRIPTION
Since CMake-4 will abort, if cmake_minimum_required is lower than 3.10, we should raised to this version. Current CMakeLists.txt is compatible, so we don't need to change anything else.

This fixed that issue:
* QA Notice: Compatibility with CMake < 3.10 will be removed in a future release.
* See also tracker bug #964405; check existing or file a new bug for this package.
* If not fixed in upstream's code repository, we should make sure they are aware. *
* The following files are causing warnings:
*   CMakeLists.txt:3.7.2
*
* An upstreamable patch should take any resulting CMake policy changes
* into account. See also:
*   https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html