### PR TITLE
Only read 1 bytes of EEPROM to check force_bt bit

### DIFF
--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -1692,7 +1692,7 @@ found:
 	/* Hack to force the Bias T to always be on if we set the IR-Endpoint
 	* bit in the EEPROM to 0. Default on EEPROM is 1.
 	*/
-	r = rtlsdr_read_eeprom(dev, buf, 0, EEPROM_SIZE);
+	r = rtlsdr_read_eeprom(dev, &buf[7], 7, 1);
 	dev->force_bt = (buf[7] & 0x02) ? 0 : 1;
 	if(dev->force_bt)
 		rtlsdr_set_bias_tee(dev, 1);


### PR DESCRIPTION
```c
r = rtlsdr_read_eeprom(dev, buf, 0, EEPROM_SIZE);
	dev->force_bt = (buf[7] & 0x02) ? 0 : 1;
	if(dev->force_bt)
		rtlsdr_set_bias_tee(dev, 1);
```

Reading 256 bytes from EEPROM via single byte I2C reads over USB is a bit slow. When you only need 1 bit.


## librtlsdr (blog)

```
$ time rtl_biast -b 0
Found 1 device(s):
  0:  RTLSDRBlog, Blog V4, SN: 00000001

Using device 0: Generic RTL2832U OEM
Found Rafael Micro R828D tuner
RTL-SDR Blog V4 Detected

________________________________________________________
Executed in    1.12 secs      fish           external
   usr time   42.03 millis    2.02 millis   40.00 millis
   sys time   68.63 millis    2.05 millis   66.58 millis
```

## librtlsdr (blog, but only read 1 bytes from EEPROM for force_bt)

```
$ time ./rtl_biast -b 0
Found 1 device(s):
  0:  RTLSDRBlog, Blog V4, SN: 00000001

Using device 0: Generic RTL2832U OEM
Found Rafael Micro R828D tuner
RTL-SDR Blog V4 Detected

________________________________________________________
Executed in  528.12 millis    fish           external
   usr time   39.29 millis    1.79 millis   37.50 millis
   sys time   29.24 millis    0.00 millis   29.24 millis
```

I think you also don't need to allocate `buf` this large then.